### PR TITLE
Make overlap support Strings and Fix  warning about complement

### DIFF
--- a/src/Algorithm/overlap.jl
+++ b/src/Algorithm/overlap.jl
@@ -3,6 +3,10 @@ function distance_threshold(overlap_len)
     return min(6, overlap_len/10.0)
 end
 
+function overlap(r1::@compat String, r2::@compat String)
+    overlap(dna(r1), dna(r2))
+end
+
 """
 calculate the overlap length of a pair of reads
 """

--- a/src/Base/Types/Types.jl
+++ b/src/Base/Types/Types.jl
@@ -35,11 +35,14 @@ export VcfHeader,
 	Gtf
 
 import Base: convert,
-        complement,
 	==,
 	-,
 	!,
 	~
+
+@static if VERSION < v"0.5.0-"
+    import complement
+end
 
 export DNA_SEQ,
 	RNA_SEQ,

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,2 +1,2 @@
-import Compat:ASCIIString
+import Compat:ASCIIString,String
     readall


### PR DESCRIPTION
- Make overlap support Strings.
  This can hidde `Sequence`, `dna` and other `OpenGene` self-defined objects from users and lower the price of using `OpenGene`.
- Fix `complement` warning since it is removed on Julia master.
